### PR TITLE
Update extension.ts

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,12 +3,30 @@ import { SetupGranitePage } from "./panels/setupGranitePage";
 import { Telemetry } from "./telemetry";
 
 export async function activate(context: ExtensionContext) {
+  // Initialize telemetry
   await Telemetry.initialize(context);
+
+  // Register the setup command
   const setupGraniteCmd = commands.registerCommand("vscode-granite.setup", async () => {
     await Telemetry.send("granite.commands.setup");
     SetupGranitePage.render(context.extensionUri, context.extensionMode);
   });
   context.subscriptions.push(setupGraniteCmd);
-  // TODO check initial startup status
-  return commands.executeCommand('vscode-granite.setup');
+
+  // Check if the setup has already run using globalState
+  const hasRunBefore = context.globalState.get('hasRunSetup', false);
+
+  // Check if we are in dev mode using the OLLAMA_MOCK environment variable
+  const isDevMode = process.env.OLLAMA_MOCK === 'true';
+
+  // If the setup hasn't run before or if we are in dev mode, show the welcome page
+  if (!hasRunBefore || isDevMode) {
+    // Set the flag in global storage indicating that setup has been completed
+    await context.globalState.update('hasRunSetup', true);
+
+    // Execute the setup command to show the welcome page
+    return commands.executeCommand('vscode-granite.setup');
+  }
+
+  // No setup required if it has been run before and we're not in dev mode
 }


### PR DESCRIPTION
added and store a flag in global storage (hasRunSetup) and tested against an environment variable (OLLAMA_MOCK) to ensure it always starts when running the extension host in dev mode.
once all the granite models are installed it will not show the welcome page. 